### PR TITLE
OOM error on some devices due to larger files is fixed.

### DIFF
--- a/alice/src/main/java/com/rockaport/alice/Alice.java
+++ b/alice/src/main/java/com/rockaport/alice/Alice.java
@@ -250,7 +250,7 @@ public class Alice {
             // write the initialization vector
             bufferedOutputStream.write(initializationVector);
 
-            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) > 0) {
+            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {
                 // encrypt
                 encryptedBytes = cipher.update(inputStreamBuffer, 0, bytesRead);
 
@@ -323,7 +323,7 @@ public class Alice {
             // allocate variables
             int bytesRead;
             byte[] inputStreamBuffer = new byte[4096];
-            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) > 0) {
+            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {
                 // encrypt
                 bufferedOutputStream.write(cipher.update(inputStreamBuffer, 0, bytesRead));
             }
@@ -464,7 +464,7 @@ public class Alice {
             }
 
             // decrypt
-            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) > 0) {
+            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {
                 numBytesToProcess = (bytesRead < bytesLeft) ? bytesRead : (int) bytesLeft;
 
                 if (numBytesToProcess <= 0) {
@@ -548,7 +548,7 @@ public class Alice {
             byte[] inputStreamBuffer = new byte[4096];
 
             // decrypt
-            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) > 0) {
+            while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {
                 bufferedOutputStream.write(cipher.update(inputStreamBuffer, 0, bytesRead));
             }
 

--- a/alice/src/main/java/com/rockaport/alice/Alice.java
+++ b/alice/src/main/java/com/rockaport/alice/Alice.java
@@ -241,7 +241,7 @@ public class Alice {
             // allocate variables
             int bytesRead;
             byte[] encryptedBytes;
-            byte[] inputStreamBuffer = new byte[4096];
+            byte[] inputStreamBuffer = new byte[1024];
 
             // setup streams
             bufferedInputStream = new BufferedInputStream(new FileInputStream(input));
@@ -322,7 +322,7 @@ public class Alice {
 
             // allocate variables
             int bytesRead;
-            byte[] inputStreamBuffer = new byte[4096];
+            byte[] inputStreamBuffer = new byte[1024];
             while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {
                 // encrypt
                 bufferedOutputStream.write(cipher.update(inputStreamBuffer, 0, bytesRead));
@@ -455,7 +455,7 @@ public class Alice {
             // allocate loop buffers and variables
             int bytesRead;
             int numBytesToProcess;
-            byte[] inputStreamBuffer = new byte[4096];
+            byte[] inputStreamBuffer = new byte[1024];
             long bytesLeft = input.length() - context.getIvLength();
 
             // subtract the mac length if enabled
@@ -545,7 +545,7 @@ public class Alice {
 
             // allocate loop buffers and variables
             int bytesRead;
-            byte[] inputStreamBuffer = new byte[4096];
+            byte[] inputStreamBuffer = new byte[1024];
 
             // decrypt
             while ((bytesRead = bufferedInputStream.read(inputStreamBuffer)) != -1) {


### PR DESCRIPTION
The encryption and decryption method throw OOM error for larger files on certain devices (Example is Samsung Galaxy J7, Samsung S5...). The while loop and byte[] are being modified to fix this bug.